### PR TITLE
do not reload the resources, if resource pack order didn't change

### DIFF
--- a/src/main/java/com/themysterys/spu/PackManager.java
+++ b/src/main/java/com/themysterys/spu/PackManager.java
@@ -34,7 +34,7 @@ public class PackManager {
     private static void generateFoldersAndFiles() {
         if (!folder.exists()) {
             System.out.println("[Server Pack Unlocker] Creating new config folder");
-            folder.mkdir();
+            folder.mkdirs();
         }
         if (folder.isDirectory()) {
             configFile = new File(folder, "pack-order.json");

--- a/src/main/java/com/themysterys/spu/mixin/GameOptionsMixin.java
+++ b/src/main/java/com/themysterys/spu/mixin/GameOptionsMixin.java
@@ -1,0 +1,34 @@
+package com.themysterys.spu.mixin;
+
+import com.themysterys.spu.ServerPackUnlocker;
+import net.minecraft.client.option.GameOptions;
+import net.minecraft.resource.ResourcePackManager;
+import net.minecraft.resource.ResourcePackProfile;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mixin(GameOptions.class)
+public class GameOptionsMixin {
+
+    @Shadow public List<String> resourcePacks;
+
+    @Inject(method = "refreshResourcePacks", at = @At("HEAD"))
+    private void onRefreshResourcePacks(ResourcePackManager resourcePackManager, CallbackInfo ci) {
+        if (ServerPackUnlocker.getCurrentServerPack() == null) return;
+        if (this.resourcePacks.contains("server")) return;
+        List<String> updatedPacks = resourcePackManager.getEnabledProfiles().stream()
+                .filter(rp -> !rp.isPinned())
+                .map(ResourcePackProfile::getName)
+                .collect(Collectors.toList());
+        int serverPackIndex = updatedPacks.indexOf("server");
+        if (serverPackIndex == -1)
+            serverPackIndex = this.resourcePacks.size();
+        this.resourcePacks.add(Math.min(this.resourcePacks.size(), serverPackIndex), "server");
+    }
+}

--- a/src/main/resources/spu.mixins.json
+++ b/src/main/resources/spu.mixins.json
@@ -4,6 +4,7 @@
   "package": "com.themysterys.spu.mixin",
   "compatibilityLevel": "JAVA_8",
   "client": [
+    "GameOptionsMixin",
     "PackScreenMixin",
     "ServerResourcePackProviderMixin"
   ],


### PR DESCRIPTION
The issue I intend to fix with this PR is, that the resource pack loading screen will show up upon closing the resource pack selection screen, even if no change was made in the screen. This happens, because Minecraft detects a new resource pack ("server") and triggers a reload. Not sure if this is the "right" way to fix this, but it works (on my machine).
Additionally I fixed a crash during startup, which happened to me in the dev environment, because the config folder was not created while Server-Pack-Unlocker loads, not sure if this could happen in a real environment.